### PR TITLE
fix git-dir under certain os such as the windows

### DIFF
--- a/src/ModmanGenerator/Vcs/Git.php
+++ b/src/ModmanGenerator/Vcs/Git.php
@@ -19,7 +19,7 @@ class Git implements AdapterInterface
     {
         $gitRoot = $this->getRoot() . '/.git';
         $ignoreFiles = implode('|', $ignoreFiles);
-        $files = `git --git-dir=$gitRoot ls-files | grep -vE "($ignoreFiles)"`;
+        $files = `git --git-dir="$gitRoot" ls-files | grep -vE "($ignoreFiles)"`;
         return $asPlainText ? $files : explode(PHP_EOL, $files);
     }
 


### PR DESCRIPTION
Under windows if the $gitRoot contains space character or other special characters in it then git will report error " unknow git command"
A example is:  E:/test  test1/test test2/.git
